### PR TITLE
Fix typo in hunger fade in event

### DIFF
--- a/hudmenu/scripts/HUDRightMeters.as
+++ b/hudmenu/scripts/HUDRightMeters.as
@@ -323,7 +323,7 @@ package
          {
             this.bShowHunger = true;
             this.HUDHungerMeter_mc.gotoAndPlay("rollOn");
-            dispatchEvent(new Event("HUD::HungerFadeIn"));
+            dispatchEvent(new Event("HUD::HungerFadedIn"));
          }
       }
       


### PR DESCRIPTION
These use the past tense "faded" instead of present tense "fade".